### PR TITLE
指定したブランチのビルドが走るGitHubActions用のスクリプトを追加する

### DIFF
--- a/.github/workflows/android_build_ci.yml
+++ b/.github/workflows/android_build_ci.yml
@@ -4,9 +4,19 @@ on:
   workflow_dispatch:
 
 jobs:
-  say_hello:
+  build:
     runs-on: ubuntu-latest
     steps:
       - run: echo "Android CI Build"
+
       - name: checkout
         uses: actions/checkout@v2
+
+      - name: set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: '11'
+
+      - name: Run Compile
+        run: ./gradlew assembleDebug

--- a/.github/workflows/android_build_ci.yml
+++ b/.github/workflows/android_build_ci.yml
@@ -18,5 +18,9 @@ jobs:
           distribution: 'zulu'
           java-version: '11'
 
+      # そのまま実行すると./gradlew: Permission deniedが出るので権限を付与する
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+
       - name: Run Compile
         run: ./gradlew assembleDebug

--- a/.github/workflows/android_build_ci.yml
+++ b/.github/workflows/android_build_ci.yml
@@ -8,3 +8,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: echo "Android CI Build"
+      - name: checkout
+        uses: actions/checkout@v2

--- a/.github/workflows/android_pr_build_check.yml
+++ b/.github/workflows/android_pr_build_check.yml
@@ -1,0 +1,28 @@
+name: Android PR Build Check
+
+on: 
+  pull_request:
+    branches:
+      - 'develop'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Android CI Build"
+
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - name: set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: '11'
+
+      # そのまま実行すると./gradlew: Permission deniedが出るので権限を付与する
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+
+      - name: Run Compile
+        run: ./gradlew assembleDebug


### PR DESCRIPTION
# やったこと
- workflow_dispatch(Actionsタブで実行できる)用のandroid_build_ci.ymlを作成
- android_build_ci.ymlを基にPR作成時にビルドが走るandroid_pr_build_check.ymlを追加
# 参考
- https://qiita.com/mu-suke08/items/5272130fd3636692bf03
- https://qiita.com/kihara-takahiro/items/687b2d10eeb559c03391
- https://zenn.dev/ryo_kawamata/articles/github-actions-specific-branch